### PR TITLE
Fix HTML parsing

### DIFF
--- a/app/scraper/scraper.js
+++ b/app/scraper/scraper.js
@@ -31,7 +31,11 @@ const extractEpisodeMetadata = async (urls) => {
   for (const url of urls) {
     const raw = await fetch(url);
     const htmlText = await raw.text();
-    const doc = new dom().parseFromString(htmlText);
+    const target = htmlText
+      .split("\n")
+      .filter((line) => line.indexOf("window.__PRELOADED_STATE__") > 0)[0];
+
+    const doc = new dom().parseFromString(target);
     const rawText = xpath.select(
       'string(//script//text()[contains(., "window.__PRELOADED_STATE__")])',
       doc


### PR DESCRIPTION
- split page into lines and extract required line

Hot fix - root cause unknown, but something changed in the page HTML that broke parsing. However, by looking at the source HTML, we can see that the relevant `<script>` node containing the show JSON is on a single line, so we can just extract that line and process from there. 