### PR TITLE
Update tracklists

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,23 @@
                 "--runInBand",
                 "--watchAll=false"
             ]
+        },
+        {
+            "type": "node",
+            "name": "debug tasks",
+            "request": "launch",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "cwd": "${workspaceFolder}",
+            "runtimeExecutable": "npm",
+            "args": [
+                "run",
+                "tasks",
+                "--",
+                "--runInBand",
+                "--watchAll=false"
+            ]
         }
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY package* ./
 
-RUN npm install
+RUN npm ci
 
 COPY . .
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+build:
+	docker build -t soundscrape .
+
+shell: build
+	docker run -it --entrypoint /bin/sh --rm -v $$(pwd):/app:delegated --name soundscrape-container soundscrape
+
+tasks: build
+	docker run -it --rm -v $$(pwd):/app:delegated --name soundscrape-container soundscrape npm run tasks
+
+tests: build
+	docker run -it --rm -v $$(pwd):/app:delegated --name soundscrape-container soundscrape npm test
+
+coverage: build
+	docker run -it --rm -v $$(pwd):/app:delegated --name soundscrape-container soundscrape npm run coverage

--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,8 @@ tasks: build
 tests: build
 	docker run -it --rm -v $$(pwd):/app:delegated --name soundscrape-container soundscrape npm test
 
+tests-interactive: build
+	docker run -it --rm -v $$(pwd):/app:delegated --name soundscrape-container soundscrape npm run test:watch
+
 coverage: build
 	docker run -it --rm -v $$(pwd):/app:delegated --name soundscrape-container soundscrape npm run coverage

--- a/app/spotify/auth.test.js
+++ b/app/spotify/auth.test.js
@@ -108,4 +108,25 @@ describe("auth.js", () => {
       );
     });
   });
+
+  describe("printAuthorizeUrl", () => {
+    it("is called with the correct scopes", () => {
+      mockFs = jest.fn().mockReturnValue("{}");
+      fs.readFileSync = mockFs;
+      const mockCreateAuthUrl = jest.fn();
+      MockApi.prototype.createAuthorizeURL = mockCreateAuthUrl;
+
+      underTest.printAuthorizeUrl();
+
+      expect(mockCreateAuthUrl).toHaveBeenCalledWith(
+        [
+          "playlist-modify-private",
+          "playlist-read-private",
+          "user-library-read",
+          "user-library-modify",
+        ],
+        "should-appear-on-callback-url"
+      );
+    });
+  });
 });

--- a/app/spotify/utils.js
+++ b/app/spotify/utils.js
@@ -1,0 +1,26 @@
+const { webApi } = require("./auth");
+const { report } = require("../utils/logger");
+
+const getPlaylists = async () => {
+  let existingPlaylistNames;
+  const playlistData = {};
+  await webApi()
+    .getUserPlaylists({ limit: 50 })
+    .then((data) => {
+      existingPlaylistNames = data.body.items.map((x) => x.name);
+      data.body.items.forEach((playlist) => {
+        playlistData[playlist.name] = {
+          trackCount: playlist.tracks.total,
+          id: playlist.id,
+        };
+      });
+    })
+    .catch((err) => console.error(err))
+    .finally(() => report("Existing playlists retrieved"));
+
+  return { existingPlaylistNames, playlistData };
+};
+
+module.exports = {
+  getPlaylists,
+};

--- a/app/spotify/utils.test.js
+++ b/app/spotify/utils.test.js
@@ -1,0 +1,47 @@
+const { getPlaylists } = require("./utils");
+const auth = require("../spotify/auth");
+jest.mock("../spotify/auth");
+const mockApi = require("spotify-web-api-node");
+jest.mock("spotify-web-api-node");
+
+describe("Spotify Utils", () => {
+  describe("getPlaylists", () => {
+    it("returns an object with playlist", async () => {
+      auth.webApi.mockReturnValue(mockApi);
+      mockApi.getUserPlaylists = jest.fn().mockResolvedValue({
+        body: {
+          items: [
+            {
+              name: "playlist1",
+              tracks: {
+                total: 1,
+              },
+              id: "pl1",
+            },
+            {
+              name: "playlist2",
+              tracks: {
+                total: 12,
+              },
+              id: "pl2",
+            },
+          ],
+        },
+      });
+      const actual = await getPlaylists();
+      expect(actual).toMatchObject({
+        existingPlaylistNames: ["playlist1", "playlist2"],
+        playlistData: {
+          playlist1: {
+            trackCount: 1,
+            id: "pl1",
+          },
+          playlist2: {
+            trackCount: 12,
+            id: "pl2",
+          },
+        },
+      });
+    });
+  });
+});

--- a/app/tasks/tasks.js
+++ b/app/tasks/tasks.js
@@ -2,6 +2,7 @@ const { report } = require("../utils/logger");
 const fs = require("fs");
 const { init, webApi } = require("../spotify/auth");
 const { getTracklists } = require("../scraper/scraper");
+const { getPlaylists } = require("../spotify/utils");
 
 const createSpotifyPlaylists = async () => {
   const showTracklists = await getTracklists();
@@ -9,21 +10,49 @@ const createSpotifyPlaylists = async () => {
   report("Initialising the web client...");
   await init();
 
-  let existingPlaylists;
-  await webApi()
-    .getUserPlaylists({ limit: 50 })
-    .then((data) => (existingPlaylists = data.body.items.map((x) => x.name)))
-    .catch((err) => console.error(err))
-    .finally(() => report("Existing playlists retrieved"));
+  // const { playlists, playlistData, playlistDataExtra } = await getPlaylists();
+  const { existingPlaylistNames, playlistData } = await getPlaylists();
 
   for await (const show of Object.values(showTracklists)) {
-    const { showNameDate } = show.info;
+    const { showNameDate, spotifyUris } = show.info;
+    const actualTrackCount = spotifyUris.length;
 
-    if (existingPlaylists.includes(showNameDate)) {
-      report(`${showNameDate} playlist already exists! Skipping...`);
+    if (existingPlaylistNames.includes(showNameDate)) {
+      const matchingPlaylist = playlistData[showNameDate];
+      const playlistTrackCount = matchingPlaylist["trackCount"];
+      if (actualTrackCount > playlistTrackCount) {
+        report(
+          `⚠️ Saved playlist ${showNameDate} has ${playlistTrackCount} tracks, latest BBC data has ${actualTrackCount}`
+        );
+        const playlistId = matchingPlaylist["id"];
+        let oldTracks = [];
+        await webApi()
+          .getPlaylist(playlistId)
+          .then(
+            (data) =>
+              (oldTracks = data.body.tracks.items.map((e) => {
+                return { uri: e.track.uri };
+              }))
+          )
+          .catch((err) => {
+            console.error(err);
+          });
+
+        await webApi()
+          .removeTracksFromPlaylist(playlistId, oldTracks)
+          .catch((err) => console.error(err));
+
+        await webApi()
+          .addTracksToPlaylist(playlistId, show.info.spotifyUris)
+          .catch((err) => console.error(err));
+
+        report(`👍🏼 ${showNameDate} updated with missing tracks`);
+      } else {
+        report(`${showNameDate} playlist already exists! Skipping...`);
+      }
       continue;
     }
-    if (show.info.spotifyUris.length === 0) {
+    if (spotifyUris.length === 0) {
       report(`There were no tracks for ${showNameDate}, skipping...`);
       continue;
     }
@@ -42,8 +71,7 @@ const createSpotifyPlaylists = async () => {
       .then((data) =>
         report(`Tracks successfully added to playlist ${showNameDate}`)
       )
-      .catch((err) => report(`Error encoutered ${err}`))
-      .finally(() => report(`Finished attempting to create ${showNameDate}`));
+      .catch((err) => report(`Error encoutered ${err}`));
   }
 };
 

--- a/app/tasks/tasks.js
+++ b/app/tasks/tasks.js
@@ -10,7 +10,6 @@ const createSpotifyPlaylists = async () => {
   report("Initialising the web client...");
   await init();
 
-  // const { playlists, playlistData, playlistDataExtra } = await getPlaylists();
   const { existingPlaylistNames, playlistData } = await getPlaylists();
 
   for await (const show of Object.values(showTracklists)) {

--- a/app/tasks/tasks.test.js
+++ b/app/tasks/tasks.test.js
@@ -35,6 +35,7 @@ describe("createSpotifyPlaylists", () => {
     getTracklists.mockResolvedValue(mockTracklisting);
 
     auth.webApi.mockReturnValue(mockApi);
+    mockApi.getUserPlaylists = jest.fn();
 
     getPlaylists.mockReturnValue({
       existingPlaylistNames: ["My Playlist 1"],

--- a/app/tasks/tasks.test.js
+++ b/app/tasks/tasks.test.js
@@ -12,6 +12,9 @@ const { report } = require("../utils/logger");
 jest.mock("../utils/logger");
 report.mockImplementation = (text) => {}; // no-op};
 
+const { getPlaylists } = require("../spotify/utils");
+jest.mock("../spotify/utils");
+
 const mockTracklisting = {
   m0010hfn: {
     info: {
@@ -33,9 +36,15 @@ describe("createSpotifyPlaylists", () => {
 
     auth.webApi.mockReturnValue(mockApi);
 
-    mockApi.getUserPlaylists = jest
-      .fn()
-      .mockResolvedValue({ body: { items: [{ name: "My Playlist 1" }] } });
+    getPlaylists.mockReturnValue({
+      existingPlaylistNames: ["My Playlist 1"],
+      playlistData: {
+        "My Playlist 1": {
+          trackCount: 1,
+          id: "mpl1",
+        },
+      },
+    });
 
     mockApi.createPlaylist = jest
       .fn()
@@ -48,7 +57,7 @@ describe("createSpotifyPlaylists", () => {
 
     // Expectations
     expect(auth.init).toHaveBeenCalledTimes(1);
-    expect(mockApi.getUserPlaylists).toHaveBeenCalledTimes(1);
+    expect(getPlaylists).toHaveBeenCalledTimes(1);
     expect(mockApi.createPlaylist.mock.calls[0][0]).toEqual("mockShowName");
     expect(mockApi.createPlaylist).toHaveBeenCalledTimes(1);
     expect(mockApi.addTracksToPlaylist).toHaveBeenCalledTimes(1);
@@ -63,11 +72,15 @@ describe("createSpotifyPlaylists", () => {
 
     auth.webApi.mockReturnValue(mockApi);
 
-    const mockGetPlaylists = jest.fn();
-    mockGetPlaylists.mockResolvedValue({
-      body: { items: [{ name: "mockShowName" }] },
+    getPlaylists.mockReturnValue({
+      existingPlaylistNames: ["mockShowName"],
+      playlistData: {
+        mockShowName: {
+          trackCount: 1,
+          id: "msn1",
+        },
+      },
     });
-    mockApi.getUserPlaylists = mockGetPlaylists;
 
     mockApi.createPlaylist = jest.fn();
 
@@ -77,8 +90,58 @@ describe("createSpotifyPlaylists", () => {
     await createSpotifyPlaylists();
     // Expectations
     expect(auth.init).toHaveBeenCalledTimes(1);
-    expect(mockApi.getUserPlaylists).toHaveBeenCalledTimes(1);
+    expect(getPlaylists).toHaveBeenCalledTimes(1);
     expect(mockApi.createPlaylist).not.toHaveBeenCalled();
     expect(mockApi.addTracksToPlaylist).not.toHaveBeenCalled();
+  });
+
+  it("updates a playlist when scrape returns more tracks", async () => {
+    getTracklists.mockResolvedValue({
+      showId1: {
+        info: {
+          showNameDate: "show1",
+          spotifyUris: ["song1", "song2"],
+        },
+      },
+    });
+
+    auth.webApi.mockReturnValue(mockApi);
+
+    getPlaylists.mockReturnValue({
+      existingPlaylistNames: ["show1"],
+      playlistData: {
+        show1: {
+          trackCount: 1,
+          id: "msn1",
+        },
+      },
+    });
+
+    mockApi.createPlaylist = jest.fn();
+    mockApi.getPlaylist = jest.fn().mockResolvedValue({
+      body: {
+        tracks: {
+          items: [{ track: { uri: "uri1" } }],
+        },
+      },
+    });
+    mockApi.removeTracksFromPlaylist = jest.fn().mockResolvedValue({});
+
+    mockApi.addTracksToPlaylist = jest.fn().mockResolvedValue({});
+
+    // Act
+    await createSpotifyPlaylists();
+    // Expectations
+    expect(auth.init).toHaveBeenCalledTimes(1);
+    expect(getPlaylists).toHaveBeenCalledTimes(1);
+    expect(mockApi.getPlaylist).toHaveBeenCalledWith("msn1");
+    expect(mockApi.removeTracksFromPlaylist).toHaveBeenCalledWith("msn1", [
+      { uri: "uri1" },
+    ]);
+    expect(mockApi.createPlaylist).not.toHaveBeenCalled();
+    expect(mockApi.addTracksToPlaylist).toHaveBeenCalledWith("msn1", [
+      "song1",
+      "song2",
+    ]);
   });
 });

--- a/app/utils/logger.js
+++ b/app/utils/logger.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const startTime = Date.now();
 
 const report = (text) => {
-  const message = `${Date()} - ${text}\n`;
+  const message = `${new Date().toISOString()} - ${text}`;
   console.log(message);
   fs.appendFileSync(`${startTime}.log`, message);
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "coverage": "jest --coverage --silent",
     "test": "jest",
+    "test:watch": "jest --watchAll",
     "tasks": "rm *.log; node app/index.js",
     "lint:check": "prettier --check app/**/*.js",
     "lint:fix": "prettier --write app/**/*.js"


### PR DESCRIPTION
- Update playlists when scrape produces more tracks for previously added playlists
- Handle cases where the same show name appears twice in the scraped data
- Some make targets to help when running in docker.
- some extra tests to fill coverage report