### PR TITLE
HOTFIX: Exclude albums from track/uri list

### DIFF
--- a/app/scraper/scraper.js
+++ b/app/scraper/scraper.js
@@ -60,7 +60,7 @@ const extractTracklistInfo = (showMetadataMap) => {
       const uris = elem.uris.filter(
         (uri) => uri.id === "commercial-music-service-spotify",
       )[0];
-      if (uris && uris.uri) {
+      if (uris && uris.uri && !uris.uri.includes("album")) {
         spotifyTrackUrls.push(uris.uri);
         spotifyTrackUris.push("spotify:track:" + uris.uri.split("/").pop());
       }


### PR DESCRIPTION
Quick fix for when the URI string is actually an album URI. 

A better solution will come later, with better validations and tests.